### PR TITLE
[codex] simplify shared import source ref

### DIFF
--- a/.agents/_templates/README.md
+++ b/.agents/_templates/README.md
@@ -1,10 +1,11 @@
 # Template Staging
 
-This directory collects template files for shared `.agents/**/*.md` conventions.
+This directory collects template files for shared `.agents/**/*.md` conventions and related import config templates.
 
 ## Rules
 
 - Files here are source templates, not shared conventions themselves.
 - The contents are temporary working material for convention authoring.
 - These files are not meant to be scanned, published, or imported as conventions.
+- The `shared.yaml` template here is the source template for consumer repos' `.agents/.shared.yaml` file.
 - When a template is finalized, move or copy it into the appropriate shared location under `.agents/`.

--- a/.agents/_templates/shared.yaml
+++ b/.agents/_templates/shared.yaml
@@ -1,0 +1,3 @@
+ids:
+  - github-gh-auth-bootstrap
+  - editorconfig-formatting

--- a/.github/actions/import-shared-conventions/README.md
+++ b/.github/actions/import-shared-conventions/README.md
@@ -1,0 +1,26 @@
+# import-shared-conventions
+
+Composite GitHub Action for consuming repositories.
+
+## Purpose
+
+Read the consuming repo's `.agents/.shared.yml` or `.agents/.shared.yaml`, resolve the listed convention `id`s from this repository, copy the matching markdown files into `.agents/shared/<id>.md`, push a feature branch, and open a pull request.
+
+## Usage
+
+```yaml
+- uses: jangalinski/agents-conventions/.github/actions/import-shared-conventions@main
+```
+
+The consuming workflow should already check out the consumer repository before invoking the action.
+Omit `source_ref` to import from `main`. Set it only when you want to test a branch from this repository.
+
+## Workflow permissions
+
+The consuming workflow needs at least:
+
+- `contents: write`
+- `pull-requests: write`
+
+The workflow should also provide `actions/checkout` for the consumer repository before invoking this action.
+The implementation logic lives in `scripts/import_shared_conventions.py`.

--- a/.github/actions/import-shared-conventions/README.md
+++ b/.github/actions/import-shared-conventions/README.md
@@ -13,7 +13,8 @@ Read the consuming repo's `.agents/.shared.yml` or `.agents/.shared.yaml`, resol
 ```
 
 The consuming workflow should already check out the consumer repository before invoking the action.
-Omit `source_ref` to import from `main`. Set it only when you want to test a branch from this repository.
+To test a branch of this action repository, change the ref in `uses:` to that branch name.
+The optional `source_ref` input stays available for workflows that need to import from a different branch than the action ref itself.
 
 ## Workflow permissions
 

--- a/.github/actions/import-shared-conventions/README.md
+++ b/.github/actions/import-shared-conventions/README.md
@@ -24,4 +24,6 @@ The consuming workflow needs at least:
 - `pull-requests: write`
 
 The workflow should also provide `actions/checkout` for the consumer repository before invoking this action.
+GitHub Actions must be allowed to create pull requests in the consumer repo or organization, otherwise the final PR creation step will fail.
+If the repository-level toggle is greyed out, enable **Allow GitHub Actions to create and approve pull requests** at the organization level.
 The implementation logic lives in `scripts/import_shared_conventions.py`.

--- a/.github/actions/import-shared-conventions/action.yml
+++ b/.github/actions/import-shared-conventions/action.yml
@@ -1,0 +1,54 @@
+name: import-shared-conventions
+description: Import shared conventions from this repository into the consuming repository and open a pull request.
+
+inputs:
+  source_ref:
+    description: "Source repository ref to import from."
+    required: false
+    default: main
+  config_path:
+    description: "Path to the shared selector file in the consuming repository."
+    required: false
+    default: .agents/.shared.yml
+  destination_dir:
+    description: "Directory in the consuming repository where shared conventions are copied."
+    required: false
+    default: .agents/shared
+  branch_prefix:
+    description: "Feature branch prefix used for the import commit."
+    required: false
+    default: shared-conventions/import
+  commit_message:
+    description: "Commit message for the import branch."
+    required: false
+    default: Import shared conventions
+  pr_title:
+    description: "Pull request title."
+    required: false
+    default: Import shared conventions
+
+runs:
+  using: composite
+  steps:
+    - name: Check out source repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.action_repository }}
+        ref: ${{ inputs.source_ref }}
+        path: ${{ runner.temp }}/shared-conventions-source
+        fetch-depth: 1
+
+    - name: Import shared conventions
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPOSITORY: ${{ github.repository }}
+        SOURCE_REPOSITORY: ${{ github.action_repository }}
+        SOURCE_REF: ${{ inputs.source_ref }}
+        CONFIG_PATH: ${{ inputs.config_path }}
+        DESTINATION_DIR: ${{ inputs.destination_dir }}
+        BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+        COMMIT_MESSAGE: ${{ inputs.commit_message }}
+        PR_TITLE: ${{ inputs.pr_title }}
+        SOURCE_DIR: ${{ runner.temp }}/shared-conventions-source
+      run: python3 "${{ github.action_path }}/scripts/import_shared_conventions.py"

--- a/.github/actions/import-shared-conventions/action.yml
+++ b/.github/actions/import-shared-conventions/action.yml
@@ -33,9 +33,9 @@ runs:
     - name: Check out source repository
       uses: actions/checkout@v4
       with:
-        repository: ${{ github.action_repository }}
+        repository: jangalinski/agents-conventions
         ref: ${{ inputs.source_ref }}
-        path: ${{ runner.temp }}/shared-conventions-source
+        path: .shared-conventions-source
         fetch-depth: 1
 
     - name: Import shared conventions
@@ -43,12 +43,12 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         REPOSITORY: ${{ github.repository }}
-        SOURCE_REPOSITORY: ${{ github.action_repository }}
+        SOURCE_REPOSITORY: jangalinski/agents-conventions
         SOURCE_REF: ${{ inputs.source_ref }}
         CONFIG_PATH: ${{ inputs.config_path }}
         DESTINATION_DIR: ${{ inputs.destination_dir }}
         BRANCH_PREFIX: ${{ inputs.branch_prefix }}
         COMMIT_MESSAGE: ${{ inputs.commit_message }}
         PR_TITLE: ${{ inputs.pr_title }}
-        SOURCE_DIR: ${{ runner.temp }}/shared-conventions-source
+        SOURCE_DIR: ${{ github.workspace }}/.shared-conventions-source
       run: python3 "${{ github.action_path }}/scripts/import_shared_conventions.py"

--- a/.github/actions/import-shared-conventions/scripts/import_shared_conventions.py
+++ b/.github/actions/import-shared-conventions/scripts/import_shared_conventions.py
@@ -15,6 +15,23 @@ def run(cmd: list[str], *, check: bool = True, capture_output: bool = False, tex
     return subprocess.run(cmd, check=check, capture_output=capture_output, text=text)
 
 
+def create_pull_request(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode == 0:
+        return
+    stderr = (result.stderr or "").strip()
+    if "createPullRequest" in stderr or "not permitted to create or approve pull requests" in stderr:
+        message = (
+            "pull request creation was rejected by GitHub Actions permissions.\n"
+            "Enable 'Allow GitHub Actions to create and approve pull requests' for the repository or its organization,\n"
+            "or use a token with PR creation rights."
+        )
+        if stderr:
+            message = f"{message}\n\nOriginal error:\n{stderr}"
+        raise SystemExit(message)
+    raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
+
+
 def parse_frontmatter(path: pathlib.Path) -> dict:
     # We only care about the YAML frontmatter block at the top of each convention file.
     content = path.read_text(encoding="utf-8")
@@ -142,7 +159,7 @@ pr_body = "\n".join(
 )
 
 # Open the pull request back to the consumer's default branch.
-run(
+create_pull_request(
     [
         "gh",
         "pr",
@@ -159,5 +176,4 @@ run(
         pr_body,
     ]
 )
-
 print(f"Created pull request for {branch_name} against {base_branch}")

--- a/.github/actions/import-shared-conventions/scripts/import_shared_conventions.py
+++ b/.github/actions/import-shared-conventions/scripts/import_shared_conventions.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import yaml
+
+
+def run(cmd: list[str], *, check: bool = True, capture_output: bool = False, text: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=check, capture_output=capture_output, text=text)
+
+
+def parse_frontmatter(path: pathlib.Path) -> dict:
+    # We only care about the YAML frontmatter block at the top of each convention file.
+    content = path.read_text(encoding="utf-8")
+    if not content.startswith("---\n"):
+        return {}
+    parts = content.split("\n---\n", 1)
+    if len(parts) != 2:
+        return {}
+    frontmatter_text = parts[0][4:]
+    data = yaml.safe_load(frontmatter_text) or {}
+    return data if isinstance(data, dict) else {}
+
+
+source_repo = os.environ["SOURCE_REPOSITORY"]
+source_ref = os.environ["SOURCE_REF"]
+repository = os.environ["REPOSITORY"]
+config_path = os.environ["CONFIG_PATH"]
+destination_dir = os.environ["DESTINATION_DIR"]
+branch_prefix = os.environ["BRANCH_PREFIX"]
+commit_message = os.environ["COMMIT_MESSAGE"]
+pr_title = os.environ["PR_TITLE"]
+source_dir = pathlib.Path(os.environ["SOURCE_DIR"])
+workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd()))
+
+config_candidates = [
+    workspace / config_path,
+    workspace / config_path.replace(".yml", ".yaml"),
+    workspace / config_path.replace(".yaml", ".yml"),
+]
+
+config_file = next((path for path in config_candidates if path.is_file()), None)
+if config_file is None:
+    print(f"No shared config file found at {config_candidates[0]}. Skipping import.")
+    raise SystemExit(0)
+
+# The consumer config stays deliberately small for the first iteration: just a list of ids.
+shared_config = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
+ids = [str(item).strip() for item in shared_config.get("ids", []) if str(item).strip()]
+if not ids:
+    raise SystemExit(f"no ids configured in {config_file}")
+
+source_conventions_dir = source_dir / ".agents" / "conventions"
+if not source_conventions_dir.is_dir():
+    raise SystemExit(f"source conventions directory not found: {source_conventions_dir}")
+
+source_by_id: dict[str, pathlib.Path] = {}
+# Build an index so we can resolve ids to source files quickly and detect duplicates early.
+for path in sorted(source_conventions_dir.rglob("*.md")):
+    frontmatter = parse_frontmatter(path)
+    convention_id = str(frontmatter.get("id", "")).strip()
+    if not convention_id:
+        continue
+    if convention_id in source_by_id:
+        raise SystemExit(
+            f"duplicate convention id {convention_id} in {source_by_id[convention_id]} and {path}"
+        )
+    source_by_id[convention_id] = path
+
+selected_paths = []
+for convention_id in ids:
+    source_path = source_by_id.get(convention_id)
+    if source_path is None:
+        raise SystemExit(f"convention id not found in source repo: {convention_id}")
+    selected_paths.append(source_path)
+
+destination_root = workspace / destination_dir
+destination_root.mkdir(parents=True, exist_ok=True)
+expected_targets: set[pathlib.Path] = set()
+
+# Copy the selected conventions into the consumer repo using the id as the filename.
+for source_path in selected_paths:
+    frontmatter = parse_frontmatter(source_path)
+    convention_id = str(frontmatter.get("id", "")).strip()
+    target_path = destination_root / f"{convention_id}.md"
+    expected_targets.add(target_path)
+    shutil.copy2(source_path, target_path)
+
+# Remove files that are no longer selected so the destination mirrors the current config.
+for path in destination_root.glob("*.md"):
+    if path not in expected_targets:
+        path.unlink()
+
+# If nothing changed, stop early instead of creating an empty branch and PR.
+status = run(["git", "-C", str(workspace), "status", "--porcelain", destination_dir], capture_output=True).stdout.strip()
+if not status:
+    print("No shared convention changes detected. Nothing to commit.")
+    raise SystemExit(0)
+
+branch_suffix = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d%H%M%S")
+branch_name = f"{branch_prefix}-{branch_suffix}"
+
+remote_show = run(["git", "-C", str(workspace), "remote", "show", "origin"], capture_output=True).stdout
+base_branch = next((line.split(":", 1)[1].strip() for line in remote_show.splitlines() if line.startswith("  HEAD branch:")), "main") or "main"
+
+# Create the feature branch, stage the imported files, and commit them with a bot identity.
+run(["git", "-C", str(workspace), "checkout", "-b", branch_name])
+run(["git", "-C", str(workspace), "config", "user.name", "github-actions[bot]"])
+run(["git", "-C", str(workspace), "config", "user.email", "github-actions[bot]@users.noreply.github.com"])
+run(["git", "-C", str(workspace), "add", destination_dir])
+run(["git", "-C", str(workspace), "commit", "-m", commit_message])
+
+gh_token = os.environ["GH_TOKEN"]
+# Re-point origin to the consumer repo with token auth so git push works in CI.
+run(
+    [
+        "git",
+        "-C",
+        str(workspace),
+        "remote",
+        "set-url",
+        "origin",
+        f"https://x-access-token:{gh_token}@github.com/{repository}.git",
+    ]
+)
+run(["git", "-C", str(workspace), "push", "-u", "origin", branch_name])
+
+pr_body = "\n".join(
+    [
+        f"Import shared conventions from `{source_repo}@{source_ref}`.",
+        "",
+        f"Config: `{config_file.name}`",
+        "Selected ids:",
+        *[f"- `{convention_id}`" for convention_id in ids],
+    ]
+)
+
+# Open the pull request back to the consumer's default branch.
+run(
+    [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        base_branch,
+        "--head",
+        branch_name,
+        "--repo",
+        repository,
+        "--title",
+        pr_title,
+        "--body",
+        pr_body,
+    ]
+)
+
+print(f"Created pull request for {branch_name} against {base_branch}")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,11 @@ Priorities:
 - Add new agent names only when you agree to them explicitly.
 - Add new priority levels only when you agree to them explicitly.
 - Keep shared conventions machine-readable and consistent with this template.
+
+### Workflow And Action Implementation
+
+When writing GitHub workflows or GitHub actions in this repository, prefer `bash` and `python` for the implementation language.
+
+- Use `bash` for thin wrappers and shell glue.
+- Use `python` for lightweight parsing and file operations.
+- Avoid introducing Ruby, JVM tooling, or other heavier languages unless explicitly requested.

--- a/docs/client/README.md
+++ b/docs/client/README.md
@@ -1,0 +1,7 @@
+# Client Examples
+
+This folder contains copy-paste ready examples for consuming repositories.
+
+## Files
+
+- `import-shared-conventions.workflow.yml` - example workflow that imports shared conventions from this repository

--- a/docs/client/import-shared-conventions.workflow.yml
+++ b/docs/client/import-shared-conventions.workflow.yml
@@ -1,0 +1,21 @@
+name: Import shared conventions
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out consumer repository
+        uses: actions/checkout@v4
+
+      - name: Import shared conventions
+        uses: jangalinski/agents-conventions/.github/actions/import-shared-conventions@main

--- a/docs/client/import-shared-conventions.workflow.yml
+++ b/docs/client/import-shared-conventions.workflow.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Import shared conventions
-        uses: jangalinski/agents-conventions/.github/actions/import-shared-conventions@main
+        uses: jangalinski/agents-conventions/.github/actions/import-shared-conventions@codex-simplify-shared-import-source-ref

--- a/docs/decision/0002-consumer-shared-import-config.md
+++ b/docs/decision/0002-consumer-shared-import-config.md
@@ -1,0 +1,23 @@
+# Decision 0002: Use `.agents/.shared.yaml` for consumer import selection
+
+Date: 2026-04-29
+
+## Context
+
+Consuming repositories need a simple local configuration file that tells the shared-convention import workflow
+which conventions to copy from this repository.
+
+## Decision
+
+Use `.agents/.shared.yaml` in consuming repositories as the import configuration file.
+
+The first version contains:
+
+- `ids`
+
+## Consequences
+
+- The import workflow can resolve conventions by unique `id` values first.
+- Consuming repos keep the selector local and ignored alongside their agent setup.
+- The schema can later be extended to support tags, agents, or other selectors without changing the file location.
+- The source repository itself is fixed by the reusable action; only the source ref stays configurable.

--- a/docs/decision/0003-import-shared-conventions-action.md
+++ b/docs/decision/0003-import-shared-conventions-action.md
@@ -1,0 +1,28 @@
+# Decision 0003: Provide a reusable import-shared-conventions GitHub Action
+
+Date: 2026-04-29
+
+## Context
+
+Consuming repositories need a lightweight, reusable way to import selected shared conventions from this repository.
+The first selector model is a flat list of unique convention `id` values.
+
+## Decision
+
+Provide a composite GitHub Action named `import-shared-conventions`.
+
+The action:
+
+- reads `.agents/.shared.yml` or `.agents/.shared.yaml` from the consuming repository
+- checks out this repository at a configured ref
+- resolves the requested convention ids
+- copies the matching markdown files into `.agents/shared/<id>.md`
+- commits the changes on a feature branch
+- opens a pull request against the consumer's default branch
+
+## Consequences
+
+- Consumer repos can import conventions without reimplementing the lookup/copy/PR flow.
+- The action keeps the current selection model simple and id-based.
+- The source repository is implicit; consumers only override the ref when they need to test a branch.
+- Later versions can extend the selector logic to tags, agents, or other criteria without changing the basic workflow shape.


### PR DESCRIPTION
## What changed
- Simplified the shared-conventions import action so the source repository is implicit.
- Kept `source_ref` as the only source override, with `main` as the default.
- Updated the consumer example and decision notes to match the new contract.

## Why
- The action is being developed in a single-repo workflow, so passing the repository twice was redundant.
- Preserving an optional branch override still allows testing new action changes before merging.

## Validation
- `git diff --cached --check`
- Manual review of the staged YAML and action files

## Notes
- I could not run the workflow locally here; the next validation step is to exercise the consumer repo workflow against this branch if needed.